### PR TITLE
Upload transactions

### DIFF
--- a/src/etebase/index.ts
+++ b/src/etebase/index.ts
@@ -264,7 +264,7 @@ export class DominateEtebase {
     item: Item,
     imageMeta: ImageMeta,
     thumbnail: string
-  ) => {
+  ): Promise<void> => {
     const collection = await collectionManager.fetch(collectionUid);
     const oldContent = await collection.getContent(Etebase.OutputFormat.String);
 
@@ -284,8 +284,7 @@ export class DominateEtebase {
 
     return collectionManager.transaction(collection).catch((e) => {
       // TODO: if it's not a conflict something bad had happened so maybe don't retry?, else
-      console.log("CATCH");
-      console.log(e);
+      console.error(e);
       return this.updateCollection(
         collectionManager,
         collectionUid,


### PR DESCRIPTION
# Description

Uses `collection.transaction` instead of `collection.batch` when updating gallery content, preventing race conditions when the user uploads multiple images. Unfortunately it's not quite as neat as Django transactions; I had to wrap it in a `while(true)` and break when it succeeds without throwing an exception. This works but it's ugly and spams the console with errors despite them being caught. Really need to batch uploaded images so we can do just one gallery update, but this should be OK for now.

closes #117 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
