### PR TITLE
fix: don't redirect when auth.user is null

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@gliff-ai/annotate": "^0.15.8",
-        "@gliff-ai/curate": "^0.11.17",
+        "@gliff-ai/curate": "^0.12.0",
         "@gliff-ai/manage": "^0.2.47",
         "@gliff-ai/upload": "^0.1.13",
         "@material-ui/core": "^4.11.3",
@@ -1866,9 +1866,9 @@
       }
     },
     "node_modules/@gliff-ai/curate": {
-      "version": "0.11.17",
-      "resolved": "https://registry.npmjs.org/@gliff-ai/curate/-/curate-0.11.17.tgz",
-      "integrity": "sha512-JMx/wOSsq3wKFSqpXG3htdTf+/XlsMzvMjfIfXTLD8ADVTh14125pMR1QF8hvfpGAfaglH+tn2uAURW9afRTug==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@gliff-ai/curate/-/curate-0.12.0.tgz",
+      "integrity": "sha512-NTs4Vm7GhCeVFf0ixupZUza7P+VoTFNB40uUaogKYy9XuqLMg4vola+abdUBv+BbothkmkUF5IhV/xhv2W6M+g==",
       "dependencies": {
         "@gliff-ai/upload": "^0.1.13",
         "@material-ui/core": "^4.11.3",
@@ -18121,9 +18121,9 @@
       }
     },
     "@gliff-ai/curate": {
-      "version": "0.11.17",
-      "resolved": "https://registry.npmjs.org/@gliff-ai/curate/-/curate-0.11.17.tgz",
-      "integrity": "sha512-JMx/wOSsq3wKFSqpXG3htdTf+/XlsMzvMjfIfXTLD8ADVTh14125pMR1QF8hvfpGAfaglH+tn2uAURW9afRTug==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@gliff-ai/curate/-/curate-0.12.0.tgz",
+      "integrity": "sha512-NTs4Vm7GhCeVFf0ixupZUza7P+VoTFNB40uUaogKYy9XuqLMg4vola+abdUBv+BbothkmkUF5IhV/xhv2W6M+g==",
       "requires": {
         "@gliff-ai/upload": "^0.1.13",
         "@material-ui/core": "^4.11.3",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@gliff-ai/annotate": "^0.15.8",
-    "@gliff-ai/curate": "^0.11.17",
+    "@gliff-ai/curate": "^0.12.0",
     "@gliff-ai/manage": "^0.2.47",
     "@gliff-ai/upload": "^0.1.13",
     "@material-ui/core": "^4.11.3",

--- a/src/views/ResetPassword.tsx
+++ b/src/views/ResetPassword.tsx
@@ -178,11 +178,13 @@ export const ResetPassword = (props: Props): ReactElement => {
     }
   };
 
-  if (!props.etebaseInstance || !auth.user) {
+  if (!props.etebaseInstance) {
     return <Navigate to="/signin" />;
   }
 
-  return (
+  return !auth.user ? (
+    <></>
+  ) : (
     <Container component="main" maxWidth="xs">
       <CssBaseline />
 


### PR DESCRIPTION
# Description

`ResetPassword.tsx` was redirecting immediately when `!auth.user`, but it seems this is always briefly true when a page loads, and `auth.user` gets set after a second or so. So I made it just render an empty fragment when `!auth.user`, and that seems to fix it (it re-renders once `auth.user` is set).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
