### PR TITLE
fix: setting key on BaseProductIcon instead of its Button child

### DIFF
--- a/src/components/productIcons/BaseProductIcon.tsx
+++ b/src/components/productIcons/BaseProductIcon.tsx
@@ -41,7 +41,6 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 interface Props {
   tool: string;
-  buttonKey?: string;
   linkDisabled?: boolean;
   extraStyleAvatar?: string | null;
   extraStyleSvg?: string | null;
@@ -51,7 +50,6 @@ interface Props {
 
 function BaseProductIcon({
   tool,
-  buttonKey,
   linkDisabled,
   extraStyleAvatar,
   extraStyleSvg,
@@ -73,7 +71,7 @@ function BaseProductIcon({
   );
 
   return (
-    <div key={buttonKey} className={classes.outerDiv}>
+    <div className={classes.outerDiv}>
       <div className={classes.iconDiv}>
         {linkDisabled ? avatar : <Link href={`/${tool}`}>{avatar}</Link>}
         <p className={`${classes.productName} ${extraStyleName}`}>{tool}</p>
@@ -89,7 +87,6 @@ function BaseProductIcon({
 }
 
 BaseProductIcon.defaultProps = {
-  buttonKey: null,
   linkDisabled: false,
   extraStyleAvatar: null,
   extraStyleSvg: null,

--- a/src/components/productIcons/ProductIcons.tsx
+++ b/src/components/productIcons/ProductIcons.tsx
@@ -70,7 +70,7 @@ function ProductIcons(): ReactElement {
       case Status.active:
         return (
           <BaseProductIcon
-            buttonKey={key}
+            key={key}
             tool={tool}
             linkDisabled
             extraStyleAvatar={classes.noHoverAvatar}
@@ -81,7 +81,7 @@ function ProductIcons(): ReactElement {
       case Status.accessible:
         return (
           <BaseProductIcon
-            buttonKey={key}
+            key={key}
             tool={tool}
             extraStyleSvg={classes.accessibleSvg}
             extraStyleName={classes.accessibleName}
@@ -91,7 +91,7 @@ function ProductIcons(): ReactElement {
       case Status.disabled:
         return (
           <BaseProductIcon
-            buttonKey={key}
+            key={key}
             tool={tool}
             linkDisabled
             extraStyleAvatar={classes.noHoverAvatar}


### PR DESCRIPTION
# Description

Was getting `Warning: Each child in a list should have a unique "key" prop.` Found that keys were being passed down through `BaseProductIcon` components to their `Button` children, but react needs keys on the immediate children of a list, not grandchildren. So I removed the `buttonKey` prop and set `key` on `BaseProductIcon` directly instead. If someone knows why the `buttonKey` prop was important, let me know and I'll put it back in, but it wasn't preventing React from complaining about keys.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
