### PR TITLE
fix: add lint rule for unused calsses

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: ["./tsconfig.json"],
   },
-  plugins: ["@typescript-eslint"],
+  plugins: ["@typescript-eslint", "mui-unused-classes"],
   extends: [
     "eslint:recommended",
     "airbnb-typescript",
@@ -19,6 +19,7 @@ module.exports = {
       rules: {
         "global-require": 0,
         "@typescript-eslint/no-var-requires": 0,
+        "mui-unused-classes/unused-classes": 2,
         "no-void": ["error", { allowAsStatement: true }],
         "react/react-in-jsx-scope": "off", // This isn't true as of React 17
         "react/jsx-indent": "off", // this just argues with prettier, and we validate against prettier anyway

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-import": "^2.23.2",
         "eslint-plugin-jsx-a11y": "^6.4.1",
+        "eslint-plugin-mui-unused-classes": "^1.0.3",
         "eslint-plugin-prettier": "^3.3.0",
         "eslint-plugin-react": "^7.23.2",
         "eslint-plugin-react-hooks": "^4.2.0",
@@ -6388,6 +6389,15 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
+      }
+    },
+    "node_modules/eslint-plugin-mui-unused-classes": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mui-unused-classes/-/eslint-plugin-mui-unused-classes-1.0.3.tgz",
+      "integrity": "sha512-hsvoxxcL189LSyUyBvak+tK7XHKvoAiUBQpnCRyx6hLf4FTE+WWNtE9cRwcUwZvdh+E/wLHGp9JpNveQcQpUTw==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": "^7.14.0"
       }
     },
     "node_modules/eslint-plugin-prettier": {
@@ -21772,6 +21782,13 @@
         "jsx-ast-utils": "^3.1.0",
         "language-tags": "^1.0.5"
       }
+    },
+    "eslint-plugin-mui-unused-classes": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mui-unused-classes/-/eslint-plugin-mui-unused-classes-1.0.3.tgz",
+      "integrity": "sha512-hsvoxxcL189LSyUyBvak+tK7XHKvoAiUBQpnCRyx6hLf4FTE+WWNtE9cRwcUwZvdh+E/wLHGp9JpNveQcQpUTw==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-prettier": {
       "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.23.2",
     "eslint-plugin-jsx-a11y": "^6.4.1",
+    "eslint-plugin-mui-unused-classes": "^1.0.3",
     "eslint-plugin-prettier": "^3.3.0",
     "eslint-plugin-react": "^7.23.2",
     "eslint-plugin-react-hooks": "^4.2.0",

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -25,26 +25,10 @@ const useStyles = makeStyles((theme: Theme) => ({
     height: "90px",
     paddingTop: "9px",
   },
-  link: {
-    textDecoration: "none",
-    marginRight: "10px",
-    color: theme.palette.secondary.main,
-  },
   svgMedium: {
     width: "22px",
     height: "100%",
     marginLeft: "-1px",
-  },
-  paper: {
-    borderRadius: 0,
-    border: "none",
-    boxShadow: "none",
-    display: "inline-flex",
-    backgroundColor: "#FFFFFF",
-    width: "313px",
-  },
-  avatarButton: {
-    paddingTop: 0,
   },
   avatarUser: {
     width: "64px !important",
@@ -79,9 +63,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     height: "100%",
     alignItems: "center",
     display: "flex",
-  },
-  linkTooltip: {
-    textTransform: "uppercase",
   },
 }));
 

--- a/src/views/BasicPage.tsx
+++ b/src/views/BasicPage.tsx
@@ -6,6 +6,7 @@ import { imgSrc } from "@/imgSrc";
 const squiggles = imgSrc("squig-black", "png");
 
 const useStyles = makeStyles(() => ({
+  // eslint-disable-next-line mui-unused-classes/unused-classes
   "@global": {
     body: {
       backgroundImage: `url(${squiggles}),url(${squiggles})`,


### PR DESCRIPTION
Detect unused classes. "@global" needs to be ignored but we don't do that often

We probs want this in all repos