### PR TITLE
fix: make use-auth setReady after setUserProfile and not before

### DIFF
--- a/src/hooks/use-auth.tsx
+++ b/src/hooks/use-auth.tsx
@@ -46,15 +46,16 @@ function useProvideAuth(etebaseInstance: DominateEtebase) {
     }
 
     setUser(authedUser);
-    setReady(true);
     if (authedUser) {
       void getUserProfile().then(
         (profile) => {
           setUserProfile(profile);
+          setReady(true);
         },
         () => {
           // 401 / 403 error, so clear saved session:
           localStorage.removeItem("etebaseInstance");
+          setReady(true);
         }
       );
     } else {

--- a/src/wrappers/PrivateRouter.tsx
+++ b/src/wrappers/PrivateRouter.tsx
@@ -7,6 +7,13 @@ export const PrivateRoute = (props: RouteProps): ReactElement => {
   const [element, setElement] = useState<ReactElement>(<></>);
 
   useEffect(() => {
+    // catch the situation where the effect
+    // has switched from true to false
+    // and just return (this shouldn't happen)
+    if (auth.ready === false) {
+      return;
+    }
+
     // if no authorised user at all
     // redirect to signin
     if (!auth?.user) {


### PR DESCRIPTION
# Description

We were setting user.ready to True before we actually tried to set the user profile, this was effecting the PrivateRouter so it would end up redirecting to sign-in or verify-email.

We now set user.ready to True after setting the got profile or clearing the saved session.

# Dependency changes

None

# Testing

None

# Documentation

None

# Migrations (if applicable)

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New migrations have been committed
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
