### PR TITLE
fix: store name in etebase Image item metadata

### DIFF
--- a/src/etebase/index.ts
+++ b/src/etebase/index.ts
@@ -354,6 +354,7 @@ export class DominateEtebase {
       const newImageItem = await itemManager.create(
         {
           type: "gliff.image",
+          name: imageMeta.imageName,
           createdTime,
           modifiedTime: createdTime,
           width: imageMeta.width,


### PR DESCRIPTION
# Description

Realised while doing the dataset download feature that we don't actually store the image names in etebase Image items; the names are only stored in the collection content JSON (aka `GalleryTiles[]`), and it made things inconvenient.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
