### PR TITLE
Label folders

### DIFF
--- a/src/wrappers/CurateWrapper.tsx
+++ b/src/wrappers/CurateWrapper.tsx
@@ -131,18 +131,16 @@ export const CurateWrapper = (props: Props): ReactElement | null => {
     const allLabels = new Set<string>(
       collectionContent
         .map((tile) => tile.imageLabels)
-        .reduce((allLabels: string[], thisLabels: string[]) =>
-          allLabels.concat(thisLabels)
-        )
+        .reduce((acc: string[], thisLabels: string[]) => acc.concat(thisLabels))
     );
 
-    let allnames: string[] = collectionContent.map(
+    const allnames: string[] = collectionContent.map(
       (tile) => tile.metadata.imageName
     );
     const counts = {};
     for (let i = 0; i < allnames.length; i += 1) {
       if (counts[allnames[i]] > 0) {
-        allnames[i] = allnames[i] + ` (${counts[allnames[i]]})`;
+        allnames[i] += ` (${counts[allnames[i]] as number})`;
       }
       if (counts[allnames[i]] === undefined) {
         counts[allnames[i]] = 1;


### PR DESCRIPTION
# Description

Sorts images by label into subdirectories in the zip download; unlabellled images get placed in an "unlabelled" folder, images with multiple labels get duplicated across all the subdirectories that match their labels.

Made this PR about an hour ago then remembered it was (by necessity) based off the `export-dataset` branch, so I closed the PR, deleted the branch, fixed it my end with `git rebase --onto staging export-dataset label-folders` (see https://medium.com/@gabriellamedas/git-rebase-and-git-rebase-onto-a6a3f83f9cce), pushed the rebased branch and made this PR.

relates #177 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
