### PR TITLE
fix: catch free tiers and don't make stripe checkouts

### DIFF
--- a/src/views/SignUp.tsx
+++ b/src/views/SignUp.tsx
@@ -90,7 +90,12 @@ export const SignUp = (props: Props): JSX.Element => {
     setOpen(true);
   };
 
-  const tierId = query.get("tier_id") || null;
+  let tierId = query.get("tier_id") || null;
+  // the following catches free tiers
+  // and makes sure we don't start a Stripe checkout session
+  if (tierId === "1") {
+    tierId = null;
+  }
   const inviteId = query.get("invite_id") || null;
 
   useEffect(() => {


### PR DESCRIPTION
As it says on the tin - this prevents "https://gliff.app/signup?tier_id=1" from trying to start a Stripe checkout.