### PR TITLE
fix: don't show breadcrumb arrow after ANNOTATE if AUDIT is not enabled

### DIFF
--- a/src/components/productIcons/BaseProductIcon.tsx
+++ b/src/components/productIcons/BaseProductIcon.tsx
@@ -49,6 +49,7 @@ interface Props {
   extraStyleSvg?: string | null;
   extraStyleName?: string | null;
   extraStyleTrailSvg?: string | null;
+  auditEnabled?: boolean;
 }
 
 function BaseProductIcon({
@@ -60,6 +61,7 @@ function BaseProductIcon({
   extraStyleSvg,
   extraStyleName,
   extraStyleTrailSvg,
+  auditEnabled,
 }: Props): ReactElement {
   const classes = useStyles();
 
@@ -87,12 +89,14 @@ function BaseProductIcon({
         )}
         <p className={`${classes.productName} ${extraStyleName}`}>{tool}</p>
       </div>
-      {tool !== "audit" && tool !== "document" && (
-        <SVG
-          src={imgSrc("breadcrumb-trail")}
-          className={`${classes.trailSvg} ${extraStyleTrailSvg}`}
-        />
-      )}
+      {tool !== "audit" &&
+        tool !== "document" &&
+        !(tool === "annotate" && !auditEnabled) && ( // don't put an arrow after ANNOTATE if AUDIT is absent from the navbar
+          <SVG
+            src={imgSrc("breadcrumb-trail")}
+            className={`${classes.trailSvg} ${extraStyleTrailSvg}`}
+          />
+        )}
     </div>
   );
 }
@@ -105,6 +109,7 @@ BaseProductIcon.defaultProps = {
   extraStyleName: null,
   extraStyleTrailSvg: null,
   customUrlPath: null,
+  auditEnabled: false,
 };
 
 export { BaseProductIcon };

--- a/src/components/productIcons/ProductIcons.tsx
+++ b/src/components/productIcons/ProductIcons.tsx
@@ -104,6 +104,7 @@ function ProductIcons(): ReactElement {
             extraStyleAvatar={classes.noHoverAvatar}
             extraStyleSvg={classes.activeSvg}
             extraStyleName={classes.activeName}
+            auditEnabled={auth.userProfile?.team.tier.id > 1}
           />
         );
       case Status.accessible:
@@ -115,6 +116,7 @@ function ProductIcons(): ReactElement {
             extraStyleSvg={classes.accessibleSvg}
             extraStyleName={classes.accessibleName}
             extraStyleTrailSvg={classes.accessibleTrailSvg}
+            auditEnabled={auth.userProfile?.team.tier.id > 1}
           />
         );
       case Status.disabled:
@@ -126,6 +128,7 @@ function ProductIcons(): ReactElement {
             extraStyleAvatar={classes.noHoverAvatar}
             extraStyleSvg={classes.disabledSvg}
             extraStyleName={classes.disableName}
+            auditEnabled={auth.userProfile?.team.tier.id > 1}
           />
         );
       default:


### PR DESCRIPTION
As it says on the tin.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
