### PR TITLE
fix: save recovery key instead of session

### DIFF
--- a/src/hooks/use-auth.tsx
+++ b/src/hooks/use-auth.tsx
@@ -98,14 +98,12 @@ function useProvideAuth(storeInstance: DominateStore) {
     const { readable: recoveryKey, hashed } =
       storeInstance.generateRecoveryKey();
 
-    const savedSession = await storeInstance.etebaseInstance.save(hashed);
-
     const profile = await createUserProfile(
       name,
       teamId,
       inviteId,
       acceptedTermsAndConditions,
-      savedSession
+      recoveryKey.join(" ")
     );
 
     return {


### PR DESCRIPTION
## Description

Found a bug while looking at encrypting the local session. Turns out we were passing an encrypted session object as the `recoveryKey` parameter to the `create_user` endpoint (`store/server/api/user.py`), so that was getting stored by django instead of the recovery key.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
