### PR TITLE
fix: call fetchImageItems when delete finishes

### DIFF
--- a/src/wrappers/CurateWrapper.tsx
+++ b/src/wrappers/CurateWrapper.tsx
@@ -191,6 +191,9 @@ export const CurateWrapper = (props: Props): ReactElement | null => {
   const deleteImages = (imageUids: string[]): void => {
     props.storeInstance
       .deleteImages(collectionUid, imageUids, props.task, props.setTask)
+      .then(() => {
+        fetchImageItems();
+      })
       .catch((error) => {
         logger.log(error);
       });


### PR DESCRIPTION
## Description

Call `fetchImageItems` when delete finishes, this pushes the updated tiles data to CURATE so it can update without having to clear its own state directly.

See https://github.com/gliff-ai/curate/pull/229

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
