### PR TITLE
feat: add MessageDialog, show on empty dataset download

### DIFF
--- a/src/components/message/ConfirmationDialog.tsx
+++ b/src/components/message/ConfirmationDialog.tsx
@@ -110,3 +110,5 @@ export function MessageDialog(props: {
     </Dialog>
   );
 }
+
+MessageDialog.defaultProps = { okCallback: null };

--- a/src/wrappers/CurateWrapper.tsx
+++ b/src/wrappers/CurateWrapper.tsx
@@ -440,7 +440,7 @@ export const CurateWrapper = (props: Props): ReactElement | null => {
         open={showNoImageMessage}
         setOpen={setShowNoImageMessage}
         heading="Warning"
-        message={"There are no images to download!"}
+        message="There are no images to download!"
       />
     </>
   );


### PR DESCRIPTION
## Description

[This error](https://sentry.io/organizations/gliff-ai/issues/2728215090/?project=5812330) was caused by a user trying to download an empty dataset. Now CURATE will show a warning dialog instead of a console error when that happens.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
