### PR TITLE
fix: Prevent assigning images to trusted services

### DIFF
--- a/src/wrappers/CurateWrapper.tsx
+++ b/src/wrappers/CurateWrapper.tsx
@@ -355,8 +355,14 @@ export const CurateWrapper = (props: Props): ReactElement | null => {
 
     void apiRequest("/team/", "GET")
       .then((team: Team) => {
-        if (team.profiles.length !== 0) {
-          setStateIfMounted(team.profiles, setProfiles, isMounted.current);
+        const newProfiles = team.profiles
+          .filter(({ is_trusted_service }) => !is_trusted_service)
+          .map(({ email, name }) => ({
+            email,
+            name,
+          }));
+        if (newProfiles.length !== 0) {
+          setStateIfMounted(newProfiles, setProfiles, isMounted.current);
         }
       })
       .catch((e) => logger.error(e));


### PR DESCRIPTION
## Description
fixes bug where trusted services show up in the list of assignees in CURATE (thanks @cooper667).

relies on:
https://github.com/gliff-ai/store/pull/163

## Dependency changes
no

## Testing
no

## Documentation
no


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
