### PR TITLE
feat: Centre snackbar

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -144,7 +144,7 @@ export const NavBar = (props: Props): ReactElement | null => {
         open={Boolean(anchorElement)}
         onClose={handleClose}
         id="menu"
-        style={{ marginTop: "60px", marginLeft: "80px" }}
+        style={{ marginTop: "60px !important", marginLeft: "80px" }}
         transformOrigin={{
           vertical: "top",
           horizontal: "right",

--- a/src/components/ProgressSnackbar.tsx
+++ b/src/components/ProgressSnackbar.tsx
@@ -37,7 +37,14 @@ function ProgressSnackbar({ task, setTask }: Props): ReactElement {
   };
 
   return (
-    <Snackbar open={task.isLoading} onClose={handleClose}>
+    <Snackbar
+      open={task.isLoading}
+      onClose={handleClose}
+      anchorOrigin={{
+        vertical: "bottom",
+        horizontal: "center",
+      }}
+    >
       <SnackbarContent
         className={classes.snackbarContent}
         message={

--- a/src/wrappers/AnnotateWrapper.tsx
+++ b/src/wrappers/AnnotateWrapper.tsx
@@ -113,7 +113,7 @@ export const AnnotateWrapper = (props: Props): ReactElement | null => {
             onClick={() => cycleImage(false)}
             tooltipPlacement="bottom"
             disabled={!canCycle()}
-            size="large"
+            size="small"
           />
         </Card>
         <Card className={classes.cardSize}>
@@ -123,7 +123,7 @@ export const AnnotateWrapper = (props: Props): ReactElement | null => {
             onClick={() => setIsComplete((prevIsComplete) => !prevIsComplete)}
             fill={isComplete}
             tooltipPlacement="bottom"
-            size="large"
+            size="small"
           />
         </Card>
         <Card className={`${classes.cardSize} ${classes.cardRight}`}>
@@ -134,7 +134,7 @@ export const AnnotateWrapper = (props: Props): ReactElement | null => {
             onClick={() => cycleImage()}
             tooltipPlacement="bottom"
             disabled={!canCycle()}
-            size="large"
+            size="small"
           />
         </Card>
       </div>


### PR DESCRIPTION
## Description

This PR address feedback from a previous PR, it resolves: 

- Centralise the upload/download snackbar 
- Make nav bar icons small 
- Fix position of Account/billing submenu

The issue of removing the Upload and Download button when in Dominate will be address in a separate PR in Annotate. 

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [x] I have read the gliff.ai Contribution Guide.
- [x] I have requested to **pull a branch** and not from main.
- [x] I have checked all commit message styles match the requested structure.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my own code.
- [ ] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
