### PR TITLE
feat: add a checkbox to confirm recovery key has been saved

### DIFF
--- a/src/views/RecoveryKey.tsx
+++ b/src/views/RecoveryKey.tsx
@@ -1,7 +1,7 @@
-import { ReactElement } from "react";
-import { Typography, Card } from "@mui/material";
+import { ChangeEvent, ReactElement, useState } from "react";
+import { Typography, Card, FormControlLabel, Checkbox } from "@mui/material";
 import makeStyles from "@mui/styles/makeStyles";
-import { theme } from "@gliff-ai/style";
+import { black, theme } from "@gliff-ai/style";
 import { SubmitButton } from "@/components";
 
 const useStyles = makeStyles(() => ({
@@ -17,8 +17,8 @@ const useStyles = makeStyles(() => ({
   recoveryKeyParagraph: {
     marginBottom: "44px",
     marginTop: "13px",
-    color: theme.palette.text.secondary,
-    fontSize: 13,
+    color: black,
+    fontSize: "21px",
     textAlign: "center",
     width: "519px",
     "& em": {
@@ -49,7 +49,13 @@ interface Props {
 }
 
 export function RecoveryKey({ recoveryKey, callback }: Props): ReactElement {
+  const [checboxTicked, setCheckboxTicked] = useState<boolean>(false);
+
   const classes = useStyles();
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setCheckboxTicked(event.target.checked);
+  };
 
   return (
     <>
@@ -73,14 +79,32 @@ export function RecoveryKey({ recoveryKey, callback }: Props): ReactElement {
         className={classes.submitDiv}
         style={{ display: "flex", flexDirection: "column" }}
       >
-        <div>I have saved my recovery key somewhere safe</div>
+        <FormControlLabel
+          control={
+            <Checkbox
+              id="confirmRecoveryKeyIsSaved"
+              checked={checboxTicked}
+              onChange={handleChange}
+            />
+          }
+          label={
+            <Typography>
+              I confirm I have saved my recovery key and understand I won&apos;t
+              be able to recover my account and data without it.
+            </Typography>
+          }
+        />
         <form
           onSubmit={(e) => {
             e.preventDefault();
             callback();
           }}
         >
-          <SubmitButton value="Continue" loading={false} />
+          <SubmitButton
+            disabled={!checboxTicked}
+            value="Continue"
+            loading={false}
+          />
         </form>
       </div>
     </>


### PR DESCRIPTION
## Description

- Add a checkbox to confirm that users have saved their recovery key
- Only enable the continue button after the checkbox is checked
- Make the  font size of the text relating to the consequence (lost data) stand out more
 
relates gliff-ai/dominate#533 
<img width="779" alt="Screenshot 2022-02-25 at 14 29 35" src="https://user-images.githubusercontent.com/37402968/155732373-177df725-54a1-492e-88f4-2d77720be18c.png">

<img width="826" alt="Screenshot 2022-02-25 at 14 29 50" src="https://user-images.githubusercontent.com/37402968/155732360-05e81373-85e6-49aa-b3cb-482d9728230c.png">



## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [x] I have read the gliff.ai Contribution Guide.
- [x] I have requested to **pull a branch** and not from main.
- [x] I have checked all commit message styles match the requested structure.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my own code.
- [ ] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
