### PR TITLE
fix: only re-render when crossing window size threshold

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -80,10 +80,8 @@ const UserInterface = (props: Props): ReactElement | null => {
   const [tooSmall, setTooSmall] = useState(false);
 
   const handleResize = useCallback(() => {
-    console.log(`tooSmall: ${tooSmall}`);
     const tooSmallNow = window.innerWidth < 700 || window.innerHeight < 300;
     if (tooSmall !== tooSmallNow) {
-      console.log(`setting tooSmall to ${tooSmallNow}`);
       setTooSmall(tooSmallNow);
     }
   }, [tooSmall]);


### PR DESCRIPTION
## Description

DOMINATE's `UserInterface` was re-rendering on every window resize event, causing it to spam dozens of etebase requests. Had to do somewhat convoluted things with hooks to prevent that, but it seems to work now.

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the gliff.ai Contribution Guide.
- [ ] I have requested to **pull a branch** and not from main.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
