### PR TITLE
fix: manually make corrupted project error an actual error

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1094,7 +1094,9 @@ export class DominateStore {
     try {
       content = JSON.parse(await etebaseObject.getContent(OutputFormat.String));
     } catch (e) {
-      console.error(e);
+      console.error(
+        "Looks like your project is corrupted. Please contact the gliff.ai team to fix this - contact@gliff.ai"
+      );
     }
 
     // pre-migrate to V0 if necessary:


### PR DESCRIPTION
## Description

This is small and slightly hacky fix that will catch the TypeError that we see for corrupted projects but which, for some reason, is a console.log and not a console.error - and thus not caught by Sentry. This manually reraises the error. You will, therefore, see the error twice in console but Sentry will now alert us.

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [x] I have read the gliff.ai Contribution Guide.
- [x] I have requested to **pull a branch** and not from main.
- [x] I have checked all commit message styles match the requested structure.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my own code.
- [x] I have assigned **3 or less** reviewers.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
