### PR TITLE
feat: Display project audit (WIP)

### DIFF
--- a/src/wrappers/AuditWrapper.tsx
+++ b/src/wrappers/AuditWrapper.tsx
@@ -143,6 +143,8 @@ export const AuditWrapper = ({
 
   if (!auth || !collectionUid || sessions === null) return null;
 
+  const projectAuditActions = storeInstance.getProjectLevelAudit();
+
   // annotation sessions contain all the actions for a given image/user; actual sessions
   // are delimited by sessionStart and sessionEnd, so split on those here:
   const actualSessions = sessions
@@ -160,7 +162,20 @@ export const AuditWrapper = ({
       }
       return splitSessions;
     })
-    .flat();
+    .flat()
+    // convert annotation sessions into the same format as other project audit actions:
+    .map((session) => ({
+      action: {
+        type: "annotate",
+        imageName: session.imageName,
+        audit: session.audit,
+      },
+      timestamp: session.timestamp,
+      username: session.username,
+    }))
+    // mix them in with other project audit actions:
+    .concat(projectAuditActions)
+    .sort((action1, action2) => action1.timestamp - action2.timestamp);
 
   return (
     <UserInterface


### PR DESCRIPTION
## Description

Converts annotation sessions to a similar format to other project level audit actions, mixes them in with the main project audit, and passes them down to AUDIT. Need to merge https://github.com/gliff-ai/dominate/pull/776 and then pull staging into this branch before this can work, because we need the project level audit actions (will also need to write a `getProjectAudit` function for `DominateStore`).

We'll also need to add a button in MANAGE for displaying team-level audits.

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the gliff.ai Contribution Guide.
- [ ] I have requested to **pull a branch** and not from main.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
